### PR TITLE
Tcp log sender

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,14 +28,14 @@ steps:
       - cache-restore
 
   - name: init
-    image: elixir:1.7
+    image: elixir:1.11.2
     volumes:
       - name: mix
         path: /root/.mix
       - name: docker
         path: /var/run/docker.sock
     environment:
-      MIX_ENV: test    
+      MIX_ENV: test
     commands:
       - mix local.rebar --force
       - mix local.hex --force
@@ -44,7 +44,7 @@ steps:
       - cache-restore
 
   - name: compile-test
-    image: elixir:1.7
+    image: elixir:1.11.2
     volumes:
       - name: mix
         path: /root/.mix
@@ -56,7 +56,7 @@ steps:
       - init
 
   - name: format
-    image: elixir:1.7
+    image: elixir:1.11.2
     volumes:
       - name: mix
         path: /root/.mix
@@ -68,7 +68,7 @@ steps:
       - compile-test
 
   - name: credo
-    image: elixir:1.7
+    image: elixir:1.11.2
     volumes:
       - name: mix
         path: /root/.mix
@@ -80,7 +80,7 @@ steps:
       - compile-test
 
   - name: test
-    image: elixir:1.7
+    image: elixir:1.11.2
     volumes:
       - name: mix
         path: /root/.mix
@@ -92,7 +92,7 @@ steps:
       - compile-test
 
   - name: dialyzer
-    image: elixir:1.7
+    image: elixir:1.11.2
     volumes:
       - name: mix
         path: /root/.mix

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ config :logger, :prima_logger,
   - example: `[{Decimal, &Kernel.to_string/1}]`, will invoke `Kernel.to_string/1` when a `Decimal` struct is found among metadata
 - **ignore_metadata_keys** (list of strings): specify a list of root level metadata keys to remove from all logs,
   if not provided it will default to `[:conn]` for security reasons
+- **host**(:inet.socket_address()): - example: {127, 0, 0, 1},
+  **port**(:inet.port()): - example: 10518
 
 ## Sending data to Datadog agent
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,54 @@ config :logger, :prima_logger,
 - **environment** (atom): current environment
 - **metadata** (list): custom metadata to append on every log, default []
 - **metadata_serializers** (list): custom serializers for structs found in metadata, default []
-    - example: `[{Decimal, to_string}]`, will invoke `Decimal.to_string/1` when a `Decimal` struct is found among metadata
-    - example: `[{Decimal, &Kernel.to_string/1}]`, will invoke `Kernel.to_string/1` when a `Decimal` struct is found among metadata
+  - example: `[{Decimal, to_string}]`, will invoke `Decimal.to_string/1` when a `Decimal` struct is found among metadata
+  - example: `[{Decimal, &Kernel.to_string/1}]`, will invoke `Kernel.to_string/1` when a `Decimal` struct is found among metadata
 - **ignore_metadata_keys** (list of strings): specify a list of root level metadata keys to remove from all logs,
-if not provided it will default to `[:conn]` for security reasons
+  if not provided it will default to `[:conn]` for security reasons
+
+## Sending data to Datadog agent
+
+You can send directly logs to Datadog via tcp messages sent to the Datadog agent. To do so you can start the agent via
+`docker-compose up -d`. In order for the agent to work you need to have a datadog api key in your environment.
+
+```
+export DD_API_KEY=YOUR_API_KEY
+```
+
+Example of configuration with host and port for the TCPconn to forward the logs to.
+
+```elixir
+
+config :logger,
+  backends: [
+    {PrimaExLogger, :prima_logger}
+  ]
+
+config :logger, :prima_logger,
+  level: :debug,
+  metadata: :all,
+  encoder: Jason,
+  type: :stonehenge,
+  environment: :staging,
+  host: {127, 0, 0, 1},
+  port: 10518
+```
+
+You also need to add :prima_ex_logger as an extra application in the mix file of your project.
+
+```elixir
+...
+  def application do
+    [
+      mod: {YourApp.Application, []},
+      extra_applications: [..., :prima_ex_logger]
+    ]
+  end
+...
+```
+
+And finally if you want to enable the tcp forwarding you need to start your application with
+`TCP_LOGGER=true iex -S mix`.
+
+> Note!
+> The TCPconn genserver is not meant to used in production. This is only a helper for testing purposes.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ by adding `prima_ex_logger` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:prima_ex_logger, "~> 0.2.1"}
+    {:prima_ex_logger, "~> 0.3.0"}
   ]
 end
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+---
+version: "3"
+services:
+  dd-agent:
+    image: datadog/agent:7
+    environment:
+      DD_SITE: datadoghq.com
+      DD_LOGS_ENABLED: 1
+      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: 1
+      DD_CONTAINER_EXCLUDE: "name:datadog-agent"
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: 1
+      DD_API_KEY: ${DD_API_KEY}
+    volumes:
+      - ./docker/agent-conf.d/logs.yml:/etc/datadog-agent/conf.d/custom-conf.d/logs.yml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    ports:
+      - "10518:10518"

--- a/docker/agent-conf.d/logs.yml
+++ b/docker/agent-conf.d/logs.yml
@@ -1,0 +1,5 @@
+logs:
+  - type: tcp
+    port: 10518
+    service: "YOUR-SERVICE"
+    source: "TCP-LOCAL-LOG"

--- a/lib/prima_ex_logger.ex
+++ b/lib/prima_ex_logger.ex
@@ -8,7 +8,7 @@ defmodule PrimaExLogger do
   @ignored_metadata_keys ~w[ansi_color pid]a
 
   @dialyzer {:nowarn_function,
-             [init: 1, configure: 2, forge_event: 2, timestamp_to_iso: 1, log: 2]}
+             [init: 1, configure: 2, forge_event: 2, timestamp_to_iso: 1, log: 3]}
 
   alias PrimaExLogger.TCPconn
 

--- a/lib/prima_ex_logger/application.ex
+++ b/lib/prima_ex_logger/application.ex
@@ -8,7 +8,7 @@ defmodule PrimaExLogger.Application do
     port = Keyword.fetch!(env, :port)
 
     children = [
-      {PrimaExLogger.TCPconn, [host, port]}
+      {PrimaExLogger.TCPconn, [host: host, port: port]}
     ]
 
     opts = [strategy: :one_for_one, name: Naive.Application]

--- a/lib/prima_ex_logger/application.ex
+++ b/lib/prima_ex_logger/application.ex
@@ -1,7 +1,5 @@
 defmodule PrimaExLogger.Application do
   @moduledoc false
-  alias PrimaExLogger.TCPconn.State
-
   use Application
 
   def start(_type, _args) do
@@ -10,7 +8,7 @@ defmodule PrimaExLogger.Application do
     port = Keyword.fetch!(env, :port)
 
     children = [
-      {PrimaExLogger.TCPconn, %State{host: host, port: port}}
+      {PrimaExLogger.TCPconn, [host, port]}
     ]
 
     opts = [strategy: :one_for_one, name: Naive.Application]

--- a/lib/prima_ex_logger/application.ex
+++ b/lib/prima_ex_logger/application.ex
@@ -1,0 +1,19 @@
+defmodule PrimaExLogger.Application do
+  @moduledoc false
+  alias PrimaExLogger.TCPconn.State
+
+  use Application
+
+  def start(_type, _args) do
+    env = Application.get_env(:logger, :prima_logger)
+    host = Keyword.fetch!(env, :host)
+    port = Keyword.fetch!(env, :port)
+
+    children = [
+      {PrimaExLogger.TCPconn, %State{host: host, port: port}}
+    ]
+
+    opts = [strategy: :one_for_one, name: Naive.Application]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -1,0 +1,58 @@
+defmodule PrimaExLogger.TCPconn do
+  use GenServer
+  require Logger
+
+  defmodule State do
+    @enforce_keys [:host, :port]
+    defstruct [
+      :host,
+      :port,
+      opts: [],
+      timeout: 5000
+    ]
+  end
+
+  def start_link(%State{} = state) do
+    GenServer.start_link(__MODULE__, state, name: __MODULE__)
+  end
+
+  def send(data), do: GenServer.call(__MODULE__, {:send, data})
+
+  # Callbacks
+
+  @impl true
+  def init(state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:send, data}, _, %State{} = s) do
+    with {:ok, sock} <- connect(s),
+         {:ok, new_data} <- ensure_new_line(data),
+         :ok <- :gen_tcp.send(sock, new_data),
+         :ok <- :gen_tcp.shutdown(sock, :write) do
+      {:reply, :ok, s}
+    else
+      {:backoff, milliseconds, s} ->
+        Process.sleep(milliseconds)
+        {:send, data, s}
+
+      {:error, _} = error ->
+        {:disconnect, error, error, s}
+    end
+  end
+
+  defp connect(%State{host: host, port: port, opts: opts, timeout: timeout} = s) do
+    case :gen_tcp.connect(host, port, [active: false] ++ opts, timeout) do
+      {:ok, sock} ->
+        {:ok, sock}
+
+      {:error, _} ->
+        {:backoff, 1000, s}
+    end
+  end
+
+  defp ensure_new_line(data) do
+    {:ok, data |> String.trim() |> Kernel.<>("\n")}
+  end
+end

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -1,8 +1,25 @@
 defmodule PrimaExLogger.TCPconn do
+  @moduledoc """
+  A generic server process that forwards the received string
+  to a host and port via TCP. To do so uses the erlang
+  `:gen_tcp` module.
+
+  """
   use GenServer
   require Logger
 
   defmodule State do
+    @moduledoc """
+    The TCPconn state module.
+
+    Requires `:host` and `:port` as mimimum values for the
+    state to open a tcp socket.
+
+    For more information about available options for the
+    socket connection [see](https://erlang.org/doc/man/gen_tcp.html#data-types).
+
+
+    """
     @enforce_keys [:host, :port]
     defstruct [
       :host,

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -30,8 +30,8 @@ defmodule PrimaExLogger.TCPconn do
     ]
   end
 
-  def start_link(%State{} = state) do
-    GenServer.start_link(__MODULE__, state, name: __MODULE__)
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
   def send(data), do: GenServer.call(__MODULE__, {:send, data})
@@ -39,8 +39,9 @@ defmodule PrimaExLogger.TCPconn do
   # Callbacks
 
   @impl true
-  def init(%State{} = state) do
-    connect(state)
+  def init(host: host, port: port) do
+    state = %State{host: host, port: port}
+    {:ok, state}
   end
 
   @impl true

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -46,11 +46,11 @@ defmodule PrimaExLogger.TCPconn do
   @impl true
   def handle_call({:send, data}, _, %State{socket: socket} = s) do
     with {:ok, new_data} <- ensure_eof(data),
-         :ok <- :gen_tcp.send(socket, new_data) |> IO.inspect() do
+         :ok <- :gen_tcp.send(socket, new_data) do
       {:reply, :ok, s}
     else
       {:error, _} = error ->
-        IO.inspect("Send failed: #{inspect(error)}")
+        IO.puts("Send failed: #{inspect(error)}")
         {:noreply, connect(s)}
     end
   end

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -89,7 +89,7 @@ defmodule PrimaExLogger.TCPconn do
       {:error, _} = error ->
         IO.puts("Send failed: #{inspect(error)}")
 
-        {:reply, :ok, connect(s)}
+        {:reply, :error, %{s | socket: nil}, {:continue, :connect}}
     end
   end
 

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -97,6 +97,10 @@ defmodule PrimaExLogger.TCPconn do
     {:ok, s}
   end
 
+  defp connect(%State{host: host} = s) when is_binary(host) do
+    connect(%{s | host: String.to_charlist(host)})
+  end
+
   defp connect(%State{host: host, port: port, opts: opts, timeout: timeout} = s) do
     case :gen_tcp.connect(host, port, [active: false] ++ opts, timeout) do
       {:ok, socket} ->

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -79,8 +79,8 @@ defmodule PrimaExLogger.TCPconn do
       {:ok, socket} ->
         {:ok, %{s | socket: socket}}
 
-      {:error, _} ->
-        {:backoff, 1000, s}
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/prima_ex_logger/tcp_conn.ex
+++ b/lib/prima_ex_logger/tcp_conn.ex
@@ -113,6 +113,6 @@ defmodule PrimaExLogger.TCPconn do
   end
 
   defp ensure_eof(data) do
-    {:ok, data |> String.trim() |> Kernel.<>("\n") |> Kernel.<>(<<0>>)}
+    {:ok, data |> String.trim() |> Kernel.<>("\n")}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule PrimaExLogger.MixProject do
       app: :prima_ex_logger,
       version: "0.3.0",
       source_url: "https://github.com/primait/prima_ex_logger",
-      elixir: "~> 1.11.2",
+      elixir: "~> 1.11",
       deps: deps(),
       aliases: aliases(),
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,9 +4,9 @@ defmodule PrimaExLogger.MixProject do
   def project do
     [
       app: :prima_ex_logger,
-      version: "0.2.5",
+      version: "0.3.0",
       source_url: "https://github.com/primait/prima_ex_logger",
-      elixir: "~> 1.7",
+      elixir: "~> 1.11.2",
       deps: deps(),
       aliases: aliases(),
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,17 @@ defmodule PrimaExLogger.MixProject do
   end
 
   def application do
+    apps(Mix.env())
+  end
+
+  defp apps(:dev) do
+    [
+      mod: {PrimaExLogger.Application, []},
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp apps(_) do
     [
       extra_applications: [:logger]
     ]


### PR DESCRIPTION
This PR aims to help anyone that want to send the logs directly to a tcp listener.
This is not meant to be used in production as it is not load tested.

Allows you to easily see the logs in datadog via sending this logst to the agent.

# Things done: 
- docker-compose with dd agent
- logs yaml conf to enable tcp listening
- TCPcon genserver
- enable/disable via TCP_LOGGER env
- bump elixir version

![](http://g.recordit.co/WKVKuhIPV0.gif)

- [x] Correctly handle errors making the state a result tuple
