### PR TITLE
revert removal of log level check

### DIFF
--- a/lib/prima_ex_logger.ex
+++ b/lib/prima_ex_logger.ex
@@ -45,10 +45,16 @@ defmodule PrimaExLogger do
     }
   end
 
-  def handle_event(event, %{encoder: encoder} = state) do
-    event
-    |> forge_event(state)
-    |> log(encoder)
+  def handle_event({level, _, _} = event, %{level: min_level, encoder: encoder} = state) do
+    case Logger.compare_levels(level, min_level) do
+      :lt ->
+        nil
+
+      _ ->
+        event
+        |> forge_event(state)
+        |> log(encoder)
+    end
 
     {:ok, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrimaExLogger.MixProject do
   def project do
     [
       app: :prima_ex_logger,
-      version: "0.2.4",
+      version: "0.2.5",
       source_url: "https://github.com/primait/prima_ex_logger",
       elixir: "~> 1.7",
       deps: deps(),


### PR DESCRIPTION
We realized that the README was not updated accordingly with the removal of the log level check in the custom backend,
and this is misleading since if the library clients do not specify a level for logger (not the custom backend) it will
be the default (currently debug). 
So we actually introduced a breaking change since an update of the clients configuration could be possibly required.

In this patch version we revert our last change. We will reintroduce this change in a minor version along with an update of the
README specifing that the log level should be specified for logger and not for the custom logger backend.
