### PR TITLE
Remove dialyzer ignores

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
       - cache-restore
 
   - name: init
-    image: elixir:1.7
+    image: elixir:1.11
     volumes:
       - name: mix
         path: /root/.mix
@@ -44,7 +44,7 @@ steps:
       - cache-restore
 
   - name: compile-test
-    image: elixir:1.7
+    image: elixir:1.11
     volumes:
       - name: mix
         path: /root/.mix
@@ -56,7 +56,7 @@ steps:
       - init
 
   - name: format
-    image: elixir:1.7
+    image: elixir:1.11
     volumes:
       - name: mix
         path: /root/.mix
@@ -68,7 +68,7 @@ steps:
       - compile-test
 
   - name: credo
-    image: elixir:1.7
+    image: elixir:1.11
     volumes:
       - name: mix
         path: /root/.mix
@@ -80,7 +80,7 @@ steps:
       - compile-test
 
   - name: test
-    image: elixir:1.7
+    image: elixir:1.11
     volumes:
       - name: mix
         path: /root/.mix
@@ -92,7 +92,7 @@ steps:
       - compile-test
 
   - name: dialyzer
-    image: elixir:1.7
+    image: elixir:1.11
     volumes:
       - name: mix
         path: /root/.mix

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger,
   backends: [

--- a/lib/prima_ex_logger.ex
+++ b/lib/prima_ex_logger.ex
@@ -139,6 +139,8 @@ defmodule PrimaExLogger do
 
       {module, fun} when is_atom(fun) ->
         module
+        # Credo wants us to do `module.fun(v)`, but that doesn't work in Elixir..
+        # credo:disable-for-next-line Credo.Check.Refactor.Apply
         |> apply(fun, [v])
         |> to_printable(custom_serializers)
     end
@@ -173,7 +175,7 @@ defmodule PrimaExLogger do
 
   @spec log(map(), module()) :: :ok
   defp log(event, encoder) do
-    case apply(encoder, :encode, [event]) do
+    case encoder.encode(event) do
       {:ok, json} ->
         IO.puts(json)
 

--- a/lib/prima_ex_logger.ex
+++ b/lib/prima_ex_logger.ex
@@ -7,9 +7,6 @@ defmodule PrimaExLogger do
 
   @ignored_metadata_keys ~w[ansi_color pid]a
 
-  @dialyzer {:nowarn_function,
-             [init: 1, configure: 2, forge_event: 2, timestamp_to_iso: 1, log: 2]}
-
   @spec init({PrimaExLogger, atom()}) :: {:error, any()} | {:ok, any()} | {:ok, any(), :hibernate}
   def init({__MODULE__, name}) do
     {:ok, configure(name, [])}
@@ -157,27 +154,21 @@ defmodule PrimaExLogger do
 
   @spec timestamp_to_iso(tuple()) :: String.t()
   def timestamp_to_iso({{year, month, day}, {hour, minute, second, milliseconds}}) do
-    case NaiveDateTime.new(
-           %Date{
-             year: year,
-             month: month,
-             day: day
-           },
-           %Time{
-             hour: hour,
-             minute: minute,
-             second: second,
-             microsecond: {1000 * milliseconds, 6}
-           }
-         ) do
-      {:ok, ts} ->
-        ts
-        |> DateTime.from_naive!("Etc/UTC")
-        |> DateTime.to_iso8601(:extended)
-
-      _ ->
-        nil
-    end
+    NaiveDateTime.new!(
+      %Date{
+        year: year,
+        month: month,
+        day: day
+      },
+      %Time{
+        hour: hour,
+        minute: minute,
+        second: second,
+        microsecond: {1000 * milliseconds, 6}
+      }
+    )
+    |> DateTime.from_naive!("Etc/UTC")
+    |> DateTime.to_iso8601(:extended)
   end
 
   @spec log(map(), module()) :: :ok

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrimaExLogger.MixProject do
   def project do
     [
       app: :prima_ex_logger,
-      version: "0.2.5",
+      version: "0.2.6",
       source_url: "https://github.com/primait/prima_ex_logger",
       elixir: "~> 1.11",
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule PrimaExLogger.MixProject do
       app: :prima_ex_logger,
       version: "0.2.5",
       source_url: "https://github.com/primait/prima_ex_logger",
-      elixir: "~> 1.7",
+      elixir: "~> 1.11",
       deps: deps(),
       aliases: aliases(),
       description: description(),


### PR DESCRIPTION
`NaiveDateTime` building cannot fail when using the two-arguments function clause which does not allow for timezone. Replaced with `NaiveDateTime.new!`

While I was at it I also got rid of compiler and credo warnings, and updated the minimum elixir version to 1.11 to use the "new" `Config` module and `config_env()`. If there are people still using earlier versions they deserve to have their projects broken.


More PRs (improved typespecs, documentation, etc) incoming.